### PR TITLE
NEN3610 uitzondering?

### DIFF
--- a/DK_REST_API_totaal.md
+++ b/DK_REST_API_totaal.md
@@ -41,8 +41,6 @@ Het toepassingsgebied is voor Digikoppeling:
 
 *Digikoppeling moet worden toegepast op alle digitale gegevensuitwisseling met behulp van gestructureerde berichten die plaatsvindt met voorzieningen die onderdeel zijn van de GDI, waaronder de basisregistraties, of die sector-overstijgend is.*
 
-*Geautomatiseerde gegevensuitwisseling tussen informatiesystemen op basis van NEN3610 is uitgesloten van het functioneel toepassingsgebied*.
-
 Dit profiel is toe te passen bij het aanbieden van REST API's ten behoeve van het ontsluiten van overheidsinformatie en/of functionaliteit.
 
 ## DK API REST profiel


### PR DESCRIPTION
Ik vraag mij af waarom we expliciet NEN 3610 uit sluiten, ik stel voor dit te verwijderen.

NEN 3610 is denk ik in het verleden genoemd omdat er OGC standaarden zijn voor geo-data uitwisseling en je geen WUS/EBMS af wil dwingen in die context, maar waarom zou je geen REST services met daarin Geodata willen toepassen?

Ik stel voor deze regel te verwijderen. Ik denk dat ook op andere plaatsen een NEN 3610 uitzondering indien genoemd wat meer toelichting nodig zou hebben.