### PR TITLE
FSC noot

### DIFF
--- a/ch03_Digikoppeling Restful API profiel.md
+++ b/ch03_Digikoppeling Restful API profiel.md
@@ -50,6 +50,12 @@ Het is verplicht Core en Logging beide te gebruiken.
 
 <a name="f1"></a><sup>1</sup>: *De verplichting valt onder het pas-toe-of-leg-uit beginsel van het Forum Standaardisatie zoals dat geldt voor de Digikoppeling REST-API Koppelvlakstandaard.*
 
+<aside class="note" title="Toevoeging 18 april 2025">
+Omdat FSC als nieuwe standaard aan de Digikoppeling REST-API koppelvlakstandaard is toegevoegd beoordeelt het Forum Standaardisatie of deze versie van het koppelvlak (met FSC) daarmee automatisch aanspraak kan maken op de ‘pas toe of leg uit’-verplichting of dat hiervoor een aanvullende toetsing vanuit het Forum nodig is.
+
+(Verwacht wordt dat het resultaat van het onderzoek eind juli 2025 bekend is.)
+</aside>
+
 <a name="f2"></a><sup>2</sup>: *Voor bestaande implementaties is het toegestaan tot 1/1/2027 gebruik te maken van versie 1.1 van de Digikoppeling REST-API Koppelvlakstandaard.*
 
 

--- a/ch03_Digikoppeling Restful API profiel.md
+++ b/ch03_Digikoppeling Restful API profiel.md
@@ -19,7 +19,7 @@ Dit profiel is toe te passen bij het aanbieden en/of consumeren van REST API's t
 
 ### Algemeen
 
-Het Digikoppeling REST API profiel is o.a. gebaseerd op de REST-API Design Rules standaard zoals ontwikkeld door het Kennisplatform API's en in beheer gebracht bij Logius Stelsels & Standaarden: [[ADR]]
+Het Digikoppeling REST API profiel is o.a. gebaseerd op de REST-API Design Rules standaard zoals ontwikkeld door het Kennisplatform API's en in beheer gebracht bij Logius Stelsels & Standaarden: [[[ADR1]]]
 
 
 Het Digikoppeling REST API profiel conformeert zich volledig aan het normatieve deel van de REST-API Design Rules.
@@ -141,13 +141,13 @@ Het Digikoppeling REST API profiel verplicht het gebruik van een UUID V7 als Tra
 
 #### Regels
 
-Het Digikoppeling REST API profiel conformeert zich volledig aan het normatieve deel van de [[ADR]].
+Het Digikoppeling REST API profiel conformeert zich volledig aan het normatieve deel van de [[[ADR1]]].
 
  |Categorie |Principe |Toelichting |Link |
  |--- | --- |---|---|
- |Verplicht | REST-API Design Rules | Het is verplicht te voldoen aan alle (normatieve) eisen van de REST-API Design Rules |[[ADR]]. |
+ |Verplicht | REST-API Design Rules | Het is verplicht te voldoen aan alle (normatieve) eisen van de REST-API Design Rules |[[[ADR1]]]. |
 
-In onderstaande tabel worden de normatieve eisen van de [[ADR]] weergegeven:
+In onderstaande tabel worden de normatieve eisen van de [[[ADR1]]] weergegeven:
 
 Normatieve eisen van de REST API Design Rules
  |Categorie |Principe |Toelichting |Link |

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <title>
    Digikoppeling Koppelvlakstandaard REST-API
   </title>
-  <script class="remove" src="https://gitdocumentatie.logius.nl/publicatie/respec/organisation-config.js">
+  <script class="remove" src="https://logius-standaarden.github.io/publicatie/respec/organisation-config.js">
   </script>
   <script class="remove" src="js/config.js">
   </script>

--- a/js/config.js
+++ b/js/config.js
@@ -25,7 +25,7 @@ var respecConfig = {
   previousPublishVersion: "1.1.1",
   pubDomain: "dk",
   publishDate: "2025-01-30",
-  publishVersion: "2.0.2",
+  publishVersion: "2.0.3",
   shortName: "restapi",
   specStatus: "DEF",
   specType: "ST"


### PR DESCRIPTION
Inclusief permalink naar ADR 1.0.
Een _informatieve_ link naar de meest recente publicatie van ADR blijft staan.